### PR TITLE
ffrn-node-manager: init state

### DIFF
--- a/ffrn-node-manager/files/ffrn-node-manager.service.j2
+++ b/ffrn-node-manager/files/ffrn-node-manager.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=gunicorn daemon
+Requires=ffrn-node-manager.socket
+After=network.target
+
+[Service]
+Type=notify
+# the specific user that our service will run as
+User=ffrn-node-manager
+Group=ffrn-node-manager
+# another option for an even more restricted service is
+# DynamicUser=yes
+# see http://0pointer.net/blog/dynamic-users-with-systemd.html
+RuntimeDirectory=gunicorn
+WorkingDirectory=/opt/ffrn-node-manager
+ExecStart=/opt/ffrn-node-manager/venv/bin/gunicorn backend:app
+ExecReload=/bin/kill -s HUP $MAINPID
+KillMode=mixed
+TimeoutStopSec=5
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/ffrn-node-manager/files/ffrn-node-manager.socket.j2
+++ b/ffrn-node-manager/files/ffrn-node-manager.socket.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=gunicorn socket
+
+[Socket]
+ListenStream=/run/ffrn-node-manager.sock
+# Our service won't need permissions for the socket, since it
+# inherits the file descriptor by socket activation
+# only the nginx daemon will need access to the socket
+SocketUser=www-data
+# Optionally restrict the socket permissions even more.
+# SocketMode=600
+
+[Install]
+WantedBy=sockets.target

--- a/ffrn-node-manager/init.sls
+++ b/ffrn-node-manager/init.sls
@@ -1,0 +1,55 @@
+---
+include:
+  - systemd.daemon-reload
+
+ffrn-node-manager_base:
+  pkg.installed:
+    - pkgs:
+      - python3
+      - python3-venv
+
+ffrn-node-manager:
+  user.present:
+    - shell: /usr/sbin/nologin
+    - createhome: False
+  service.running:
+    - enable: True
+    - name: ffrn-node-manager.socket
+    - require:
+      - pkg: ffrn-node-manager_base
+      - virtualenv: /opt/ffrn-node-manager/venv
+
+https://github.com/Freifunk-Rhein-Neckar/ffrn-node-manager.git:
+  git.latest:
+    - target: /opt/ffrn-node-manager
+    - user: ffrn-node-manager
+    - watch_in:
+      - service: ffrn-node-manager
+      - user: ffrn-node-manager
+
+/opt/ffrn-node-manager/venv:
+  virtualenv.managed:
+    - requirements: /opt/ffrn-node-manager/requirements.txt
+    - user: ffrn-node-manager
+
+/etc/systemd/system/ffrn-node-manager.service:
+  file.managed:
+    - source: salt://ffrn-node-manager/files/ffrn-node-manager.service.j2
+    - template: jinja
+    - mode: '0644'
+    - makedirs: True
+    - onchanges_in:
+      - cmd: systemctl daemon-reload
+    - watch_in:
+      - service: ffrn-node-manager
+
+/etc/systemd/system/ffrn-node-manager.socket:
+  file.managed:
+    - source: salt://ffrn-node-manager/files/ffrn-node-manager.socket.j2
+    - template: jinja
+    - mode: '0644'
+    - makedirs: True
+    - onchanges_in:
+      - cmd: systemctl daemon-reload
+    - watch_in:
+      - service: ffrn-node-manager

--- a/top.sls
+++ b/top.sls
@@ -67,6 +67,7 @@ base:
     - www.website
     - knot.master
     - yanic.zonefile
+    - ffrn-node-manager
     # - nginx
 
   'tools-itter.ffrn.de':


### PR DESCRIPTION
Ich habe mal den [ffrn-node-manager](https://github.com/Freifunk-Rhein-Neckar/ffrn-node-manager) in einen Salt State gepackt und dabei von supervisor auf systemd umgestellt. 